### PR TITLE
商品削除機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :move_to_index, except: [:index, :show]
-  before_action :set_item, only: [:edit, :show, :update,:destroy]
+  before_action :set_item, only: [:edit, :show, :update]
   def index
     #@nickname = current_user.nickname
     # 2全ての商品のレコードをインスタンス変数に代入
@@ -27,14 +27,6 @@ class ItemsController < ApplicationController
   def update
     if @item.update(item_params)
       redirect_to :item
-    else
-      render :edit
-    end
-  end
-
-  def destroy
-    if @item.destroy
-      redirect_to :root
     else
       render :edit
     end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
   before_action :move_to_index, except: [:index, :show]
   before_action :set_item, only: [:edit, :show, :update,:destroy]
+  before_action :authenticate_user!
   def index
     #@nickname = current_user.nickname
     # 2全ての商品のレコードをインスタンス変数に代入
@@ -32,10 +33,9 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    if @item.destroy
+    if user_signed_in? && current_user.id == @item.user_id
+      @item.destroy
       redirect_to :root
-    else
-      render :edit
     end
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -36,6 +36,8 @@ class ItemsController < ApplicationController
     if user_signed_in? && current_user.id == @item.user_id
       @item.destroy
       redirect_to :root
+    else
+      render :show
     end
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :move_to_index, except: [:index, :show]
-  before_action :set_item, only: [:edit, :show, :update]
+  before_action :set_item, only: [:edit, :show, :update,:destroy]
   def index
     #@nickname = current_user.nickname
     # 2全ての商品のレコードをインスタンス変数に代入
@@ -8,7 +8,8 @@ class ItemsController < ApplicationController
   end
 
   def new
-    @item = Item.new # １インスタンス変数を定義
+    # １インスタンス変数を定義
+    @item = Item.new
   end
 
   def create
@@ -29,6 +30,16 @@ class ItemsController < ApplicationController
       render :edit
     end
   end
+
+  def destroy
+    if @item.destroy
+      redirect_to :root
+    else
+      render :edit
+    end
+  end
+
+
 
   private
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -4,13 +4,11 @@ class ItemsController < ApplicationController
   def index
     #@nickname = current_user.nickname
     # 2全ての商品のレコードをインスタンス変数に代入
-
     @item = Item.includes(:user).order("created_at DESC")
   end
 
   def new
-    # １インスタンス変数を定義
-    @item = Item.new
+    @item = Item.new # １インスタンス変数を定義
   end
 
   def create

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :move_to_index, except: [:index, :show]
-  before_action :set_item, only: [:edit, :show, :update]
+  before_action :set_item, only: [:edit, :show, :update,:destroy]
   def index
     #@nickname = current_user.nickname
     # 2全ての商品のレコードをインスタンス変数に代入
@@ -27,6 +27,14 @@ class ItemsController < ApplicationController
   def update
     if @item.update(item_params)
       redirect_to :item
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    if @item.destroy
+      redirect_to :root
     else
       render :edit
     end

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -139,7 +139,7 @@ app/assets/stylesheets/items/new.css %>
     <%# /注意書き %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
-      <%= f.submit "変更する" ,class:"sell-btn" %>
+      <%= f.submit "変更する",class:"sell-btn" %>
       <%=link_to 'もどる',item_path, class:"back-btn" %>
     </div>
     <%# /下部ボタン %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -26,7 +26,7 @@
   <% if user_signed_in? && current_user.id == @item.user_id %>    
     <%= link_to '商品の編集', edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
-    <%= link_to '削除', item_path(@item.id), method: :delete, class:'item-destroy' %>
+    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
   <% else %>
     <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
 　<% end %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -26,7 +26,7 @@
   <% if user_signed_in? && current_user.id == @item.user_id %>    
     <%= link_to '商品の編集', edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+    <%= link_to '削除', item_path(@item.id), method: :delete, class:'item-destroy' %>
   <% else %>
     <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
 　<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items, only:[:index, :new, :create, :edit, :update, :show, :destroy]
+  resources :items
   
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items, only:[:index, :new, :create, :edit, :update, :show ]
+  resources :items, only:[:index, :new, :create, :edit, :update, :show, :destroy]
   
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items, only:[:index, :new, :create, :edit, :update, :show ]
+  resources :items, only:[:index, :new, :create, :edit, :update, :show, :destroy ]
   
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items, only:[:index, :new, :create, :edit, :update, :show, :destroy ]
+  resources :items, only:[:index, :new, :create, :edit, :update, :show ]
   
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
what
出品者だけが商品情報を削除できるを実装しました。
rubocop実行済

商品を削除する前のトップページ画像
https://gyazo.com/dfec0a811e38b5303c0b849aeb87c7b1
商品編集ページ画像
https://gyazo.com/b2f7fc82633dbb0674ce9e001df6492d
商品削除後のトップページ画像
https://gyazo.com/a41219ce3668b7291c4ad45b5d19cffe

why
商品削除機能実装のため

先ほど、商品情報編集画面でLGTMをいただいてから、GitHubのブランチ作成をせずに次の削除機能を実装してしまいGitHubカリキュラムを見てやり直しました。全て直したつもりですが間違えていたらご指摘いただけると幸いです。
レビュー宜しくお願い致します。
